### PR TITLE
Fixed typo at the beginning of headers hashtable

### DIFF
--- a/GreyNoisePS/GreyNoisePS.psm1
+++ b/GreyNoisePS/GreyNoisePS.psm1
@@ -26,7 +26,7 @@ function Get-GNIpInfo {
 	process {
 		foreach ($Address in $Ip) {
 			try {
-				$out = Invoke-RestMethod -Uri "https://api.greynoise.io/v3/community/$Address" -Headers {'User-Agent' = 'AndrewPla-GreyNoisePS'; key = $Key}
+				$out = Invoke-RestMethod -Uri "https://api.greynoise.io/v3/community/$Address" -Headers @{'User-Agent' = 'AndrewPla-GreyNoisePS'; key = $Key}
 				
 				[pscustomobject]@{
 					ip             = $out.ip
@@ -116,7 +116,7 @@ function Get-GNMultiIpContext {
 		Method  = 'POST'
 		URI     = "https://api.greynoise.io/v2/noise/multi/context"
 		
-		Headers = {'User-Agent' = 'AndrewPla-GreyNoisePS'; key = $Key}
+		Headers = @{'User-Agent' = 'AndrewPla-GreyNoisePS'; key = $Key}
 		Body    = (@{ips = $Ips.IPAddressToString} | ConvertTo-Json)
 	}
 


### PR DESCRIPTION
These missing @ symbols at the beginning of the headers hashtable was causing the functions to fail. Adding the @ caused them to work.